### PR TITLE
ews-optimization: clarify sensitivity/specificity variable names and …

### DIFF
--- a/scripts/benchmark_optimization_speed.jl
+++ b/scripts/benchmark_optimization_speed.jl
@@ -278,8 +278,8 @@ function main()
                 consecutive_bounds = (2.0, 30.0),  # Custom bounds
                 n_sobol_points = n_sobol,
                 maxeval = 1000,
-                executor = FLoops.SequentialEx(),          # Executor for sequential processing
-                # executor = FLoops.ThreadedEx(),          # Executor for parallel processing
+                # executor = FLoops.SequentialEx(),          # Executor for sequential processing
+                executor = FLoops.ThreadedEx(),          # Executor for parallel processing
                 force = true,
                 return_df = true,
                 save_results = false,

--- a/src/ews-hyperparam-optimization.jl
+++ b/src/ews-hyperparam-optimization.jl
@@ -540,15 +540,22 @@ function ews_hyperparam_gridsearch!(
                 end
 
                 for (j, ews_metric) in pairs(missing_ews_metric_vec)
+                    # Calculate confusion matrix components
                     true_positives = length(
                         filter(!(==(0)), detection_index_arr[:, j])
                     )
                     true_negatives = length(
                         filter(==(0), null_detection_index_arr[:, j])
                     )
-                    sensitivity = true_positives / ensemble_nsims
-                    specificity = true_negatives / ensemble_nsims
-                    accuracy = (sensitivity + specificity) / 2
+
+                    # Explicit sample counts for each simulation type
+                    n_emergent_sims = size(detection_index_arr, 1)
+                    n_null_sims = size(null_detection_index_arr, 1)
+
+                    # Calculate performance metrics
+                    sensitivity = calculate_sensitivity(true_positives, n_emergent_sims)
+                    specificity = calculate_specificity(true_negatives, n_null_sims)
+                    balanced_accuracy = calculate_balanced_accuracy(sensitivity, specificity)
 
                     push!(
                         ews_df,
@@ -565,7 +572,7 @@ function ews_hyperparam_gridsearch!(
                             ews_metric,
                             true_positives,
                             true_negatives,
-                            accuracy,
+                            balanced_accuracy,
                             sensitivity,
                             specificity,
                         ),

--- a/src/ews-multistart-optimization.jl
+++ b/src/ews-multistart-optimization.jl
@@ -328,7 +328,8 @@ function ews_objective_function_with_tracking(
     threshold_percentile = ews_params.threshold_percentile
 
     # Calculate accuracy
-    valid_nsims = length(ews_metrics)
+    n_emergent_sims = length(ews_metrics)
+    n_null_sims = length(null_ews_metrics)
     true_positives = 0
     true_negatives = 0
 
@@ -378,9 +379,9 @@ function ews_objective_function_with_tracking(
     end
 
     # Calculate metrics
-    sensitivity = calculate_sensitivity(true_positives, valid_nsims)
-    specificity = calculate_specificity(true_negatives, valid_nsims)
-    accuracy = calculate_accuracy(sensitivity, specificity)
+    sensitivity = calculate_sensitivity(true_positives, n_emergent_sims)
+    specificity = calculate_specificity(true_negatives, n_null_sims)
+    accuracy = calculate_balanced_accuracy(sensitivity, specificity)
     loss = 1.0 - accuracy
 
     # Update tracker if this is the best solution so far

--- a/src/optimization-functions.jl
+++ b/src/optimization-functions.jl
@@ -1,7 +1,7 @@
-export calculate_sensitivity, calculate_specificity, calculate_accuracy
+export calculate_sensitivity, calculate_specificity, calculate_balanced_accuracy
 
 """
-    calculate_accuracy(sensitivity, specificity)
+    calculate_balanced_accuracy(sensitivity, specificity)
 
 Calculate the balanced accuracy from sensitivity and specificity values.
 
@@ -18,63 +18,63 @@ performance on both positive and negative cases.
 
 # Examples
 ```julia
-accuracy = calculate_accuracy(0.8, 0.9)  # Returns 0.85
+balanced_accuracy = calculate_balanced_accuracy(0.8, 0.9)  # Returns 0.85
 ```
 """
-function calculate_accuracy(sensitivity, specificity)
+function calculate_balanced_accuracy(sensitivity, specificity)
     return (sensitivity + specificity) / 2
 end
 
 """
-    calculate_sensitivity(true_positives, ensemble_nsims)
+    calculate_sensitivity(true_positives, n_emergent_sims)
 
 Calculate the sensitivity (true positive rate) from the number of true positives
-and total number of simulations.
+and total number of emergent simulations.
 
 Sensitivity measures the proportion of actual positive cases that are correctly
 identified as positive. In the context of early warning systems, this represents
-the fraction of simulations where a critical transition was correctly detected.
+the fraction of emergent simulations where a critical transition was correctly detected.
 
 # Arguments
 - `true_positives`: Number of true positive detections
-- `ensemble_nsims`: Total number of simulations in the ensemble
+- `n_emergent_sims`: Total number of emergent simulations
 
 # Returns
-- `Float64`: The sensitivity value as true_positives / ensemble_nsims
+- `Float64`: The sensitivity value as true_positives / n_emergent_sims
 
 # Examples
 ```julia
 sensitivity = calculate_sensitivity(80, 100)  # Returns 0.8
 ```
 """
-function calculate_sensitivity(true_positives, ensemble_nsims)
-    return true_positives / ensemble_nsims
+function calculate_sensitivity(true_positives, n_emergent_sims)
+    return true_positives / n_emergent_sims
 
 end
 
 """
-    calculate_specificity(true_negatives, ensemble_nsims)
+    calculate_specificity(true_negatives, n_null_sims)
 
 Calculate the specificity (true negative rate) from the number of true negatives
-and total number of simulations.
+and total number of null simulations.
 
 Specificity measures the proportion of actual negative cases that are correctly
 identified as negative. In the context of early warning systems, this represents
-the fraction of simulations where no critical transition occurred and no false
+the fraction of null simulations where no critical transition occurred and no false
 alarm was raised.
 
 # Arguments
 - `true_negatives`: Number of true negative detections
-- `ensemble_nsims`: Total number of simulations in the ensemble
+- `n_null_sims`: Total number of null simulations
 
 # Returns
-- `Float64`: The specificity value as true_negatives / ensemble_nsims
+- `Float64`: The specificity value as true_negatives / n_null_sims
 
 # Examples
 ```julia
 specificity = calculate_specificity(90, 100)  # Returns 0.9
 ```
 """
-function calculate_specificity(true_negatives, ensemble_nsims)
-    return true_negatives / ensemble_nsims
+function calculate_specificity(true_negatives, n_null_sims)
+    return true_negatives / n_null_sims
 end


### PR DESCRIPTION
…function terminology

Replace ambiguous 'accuracy' terminology with precise 'balanced_accuracy'  throughout optimization functions to clarify the metric being calculated. Update variable names from generic 'ensemble_nsims' to specific simulation type counts ('n_emergent_sims', 'n_null_sims') for improved clarity.

Changes include:
- Rename calculate_accuracy() to calculate_balanced_accuracy() in  optimization-functions.jl with updated documentation
- Update function calls across ews-hyperparam-optimization.jl and  ews-multistart-optimization.jl to use new function name
- Replace 'valid_nsims' with 'n_emergent_sims' and add 'n_null_sims' variable for explicit sample count tracking
- Update documentation and parameter names to reflect specific simulation types rather than generic ensemble terminology
- Switch benchmark script to use threaded execution instead of sequential

This improves code clarity by making the distinction between balanced accuracy (sensitivity + specificity)/2 and traditional accuracy explicit, and ensures variable names clearly indicate which simulation type they represent.