### PR TITLE
refactor: add Base.@kwdef to struct definitions for default constructors

### DIFF
--- a/src/CSDNoise.jl
+++ b/src/CSDNoise.jl
@@ -3,6 +3,7 @@ Note that each file handles exporting its local function for the API.
 """
 module CSDNoise
 using DispatchDoctor: @unstable
+using Base: Base.@kwdef
 using DrWatson: DrWatson
 using Random: Random
 using Distributions: Distributions
@@ -30,7 +31,6 @@ import REPL.TerminalMenus as RTM
 using Logging: Logging
 using LoggingExtras: LoggingExtras
 using GLMakie
-
 
 # Constants
 include("./constants/dynamics-constants.jl")

--- a/src/types/dynamics-parameters.jl
+++ b/src/types/dynamics-parameters.jl
@@ -13,7 +13,7 @@ LightSumTypes.@sumtype SeasonalityFunction(
 ) <: AbstractSeasonalityFunction
 
 
-struct DynamicsParameterSpecification
+Base.@kwdef struct DynamicsParameterSpecification
     contact_matrix::Matrix{Int64}
     beta_mean::Float64
     beta_force::Float64
@@ -64,7 +64,7 @@ function DynamicsParameterSpecification(
     )
 end
 
-struct DynamicsParameters
+Base.@kwdef struct DynamicsParameters
     contact_matrix::Matrix{Int64}
     beta_mean::Float64
     beta_force::Float64

--- a/src/types/ensemble-specifications.jl
+++ b/src/types/ensemble-specifications.jl
@@ -1,7 +1,7 @@
 export EnsembleSpecification,
     EnsembleSpecsParameters
 
-struct EnsembleSpecification
+Base.@kwdef struct EnsembleSpecification
     state_parameters::StateParameters
     dynamics_parameter_specification::DynamicsParameterSpecification
     time_parameters::SimTimeParameters
@@ -46,7 +46,7 @@ function EnsembleSpecification(
 end
 
 # TODO: Figure out if this is actually needed
-struct EnsembleSpecsParameters
+Base.@kwdef struct EnsembleSpecsParameters
     burnin_years::Int64
     nyears::Int64
     annual_births_per_k::Int64

--- a/src/types/ews-specifications.jl
+++ b/src/types/ews-specifications.jl
@@ -18,7 +18,7 @@ struct Backward end
 struct Centered end
 LightSumTypes.@sumtype EWSMethod(Backward, Centered) <: AbstractEWSMethod
 
-struct EWSMetricSpecification
+Base.@kwdef struct EWSMetricSpecification
     method::EWSMethod
     aggregation::Dates.Day
     bandwidth::Dates.Day
@@ -86,7 +86,7 @@ function _EWSMetricSpecification_path(
 end
 
 
-struct EWSMetrics
+Base.@kwdef struct EWSMetrics
     ews_specification::EWSMetricSpecification
     mean::Vector{Float64}
     variance::Vector{Float64}

--- a/src/types/noise-specifications.jl
+++ b/src/types/noise-specifications.jl
@@ -6,11 +6,11 @@ export NoiseSpecification,
 
 abstract type AbstractNoiseSpecification end
 
-struct PoissonNoise
+Base.@kwdef struct PoissonNoise
     noise_mean_scaling::Float64
 end
 
-struct DynamicalNoise
+Base.@kwdef struct DynamicalNoise
     R_0::Float64
     latent_period::Int64
     duration_infection::Int64
@@ -23,7 +23,7 @@ end
 LightSumTypes.@sumtype NoiseSpecification(PoissonNoise, DynamicalNoise) <: AbstractNoiseSpecification
 
 
-struct DynamicalNoiseSpecification
+Base.@kwdef struct DynamicalNoiseSpecification
     R0::Float64
     latent_period::Int64
     duration_infection::Int64
@@ -83,7 +83,7 @@ function DynamicalNoiseSpecification(;
     )
 end
 
-struct NoiseVaccinationOptimizationParameters
+Base.@kwdef struct NoiseVaccinationOptimizationParameters
     n_sobol_points::Int64
     local_algorithm
     maxeval::Int64

--- a/src/types/optimization-types.jl
+++ b/src/types/optimization-types.jl
@@ -13,7 +13,7 @@ export CachedSimulationData,
 Pre-computed simulation data that can be reused across parameter evaluations.
 This avoids expensive recomputation of noise arrays and test arrays.
 """
-struct CachedSimulationData
+Base.@kwdef struct CachedSimulationData
     testarr::Array{Int64, 3}
     null_testarr::Array{Int64, 3}
     thresholds::Vector{Matrix{Int64}}
@@ -27,7 +27,7 @@ end
 Struct representing a single optimization scenario with all necessary parameters
 for EWS hyperparameter optimization.
 """
-struct OptimizationScenario
+Base.@kwdef struct OptimizationScenario
     ensemble_specification::EnsembleSpecification
     null_specification::EnsembleSpecification
     noise_specification::NoiseSpecification
@@ -74,7 +74,7 @@ end
 
 Scenario for grid search including both base scenario and grid parameters.
 """
-struct GridSearchScenario
+Base.@kwdef struct GridSearchScenario
     ensemble_specification::EnsembleSpecification
     null_specification::EnsembleSpecification
     noise_specification::NoiseSpecification
@@ -144,7 +144,7 @@ The classification counts are stored as Float64 to support weighted or fractiona
 while the total simulation counts remain as integers. This struct serves as an intermediate
 representation for calculating performance metrics like sensitivity, specificity, and accuracy.
 """
-struct EWSClassificationResults
+Base.@kwdef struct EWSClassificationResults
     true_positives::Float64
     true_negatives::Float64
     false_positives::Float64
@@ -158,7 +158,7 @@ end
 
 Mutable struct to track the best solution and its metrics during optimization.
 """
-mutable struct OptimizationTracker
+Base.@kwdef mutable struct OptimizationTracker
     best_loss::Float64
     best_accuracy::Float64
     best_sensitivity::Float64
@@ -170,7 +170,7 @@ mutable struct OptimizationTracker
     end
 end
 
-struct OptimizedValues
+Base.@kwdef struct OptimizedValues
     threshold_quantile::Float64
     consecutive_thresholds::Int64
     accuracy::Float64
@@ -178,7 +178,7 @@ struct OptimizedValues
     specificity::Float64
 end
 
-struct OptimizationResult
+Base.@kwdef struct OptimizationResult
     ensemble_specification::EnsembleSpecification
     null_specification::EnsembleSpecification
     noise_specification::NoiseSpecification

--- a/src/types/outbreak-specifications.jl
+++ b/src/types/outbreak-specifications.jl
@@ -5,7 +5,7 @@ export OutbreakSpecification,
     Thresholds,
     OutbreakThresholds
 
-struct OutbreakSpecification
+Base.@kwdef struct OutbreakSpecification
     outbreak_threshold::Int64
     minimum_outbreak_duration::Int64
     minimum_outbreak_size::Int64
@@ -30,7 +30,7 @@ function OutbreakSpecification(
 end
 
 # TODO: Update to use sumtype and add implementation to testing vecs creation
-struct AlertMethod
+Base.@kwdef struct AlertMethod
     method_name::String
     function AlertMethod(method_name::String)
         available_test_methods = [
@@ -46,7 +46,7 @@ struct AlertMethod
     end
 end
 
-struct OutbreakDetectionSpecification
+Base.@kwdef struct OutbreakDetectionSpecification
     alert_threshold::Int64
     moving_average_lag::Int64
     percent_visit_clinic::Float64
@@ -97,13 +97,13 @@ end
 
 abstract type AbstractThresholds end
 
-struct Thresholds <: AbstractThresholds
+Base.@kwdef struct Thresholds <: AbstractThresholds
     lower_bounds::Vector{Int64}
     upper_bounds::Vector{Int64}
     duration::Vector{Int64}
 end
 
-struct OutbreakThresholds <: AbstractThresholds
+Base.@kwdef struct OutbreakThresholds <: AbstractThresholds
     lower_bounds::Vector{Int64}
     upper_bounds::Vector{Int64}
     duration::Vector{Int64}

--- a/src/types/scenario-specifications.jl
+++ b/src/types/scenario-specifications.jl
@@ -1,7 +1,7 @@
 export ScenarioSpecification
 
 # TODO: Doesn't seem to be used
-struct ScenarioSpecification
+Base.@kwdef struct ScenarioSpecification
     ensemble_specification::EnsembleSpecification
     outbreak_specification::OutbreakSpecification
     noise_specification::NoiseSpecification

--- a/src/types/simulation-results.jl
+++ b/src/types/simulation-results.jl
@@ -1,13 +1,13 @@
 export SEIRRun,
     NoiseRun
 
-struct SEIRRun
+Base.@kwdef struct SEIRRun
     states::Vector{StaticArrays.SVector{5, Int64}}
     incidence::Vector{Int64}
     Reff::Vector{Float64}
 end
 
-struct NoiseRun
+Base.@kwdef struct NoiseRun
     incidence::Vector{Vector{Int64}}
     mean_noise::Float64
     mean_poisson_noise::Float64

--- a/src/types/state-parameters.jl
+++ b/src/types/state-parameters.jl
@@ -1,6 +1,6 @@
 export StateParameters
 
-struct StateParameters
+Base.@kwdef struct StateParameters
     init_states::LabelledArrays.SLArray{Tuple{5}, Int64, 1, 5, (:S, :E, :I, :R, :N)}
     init_state_props::LabelledArrays.SLArray{Tuple{4}, Float64, 1, 4, (:s_prop, :e_prop, :i_prop, :r_prop)}
 end

--- a/src/types/test-specifications.jl
+++ b/src/types/test-specifications.jl
@@ -1,6 +1,6 @@
 export IndividualTestSpecification
 
-struct IndividualTestSpecification
+Base.@kwdef struct IndividualTestSpecification
     sensitivity::Float64
     specificity::Float64
     test_result_lag::Int64

--- a/src/types/time-parameters.jl
+++ b/src/types/time-parameters.jl
@@ -1,6 +1,6 @@
 export SimTimeParameters
 
-struct SimTimeParameters
+Base.@kwdef struct SimTimeParameters
     burnin::Float64
     tmin::Float64
     tmax::Float64


### PR DESCRIPTION
Add Base.@kwdef macro to all struct definitions across type modules to enable keyword-based construction with default values. This structural change improves API usability by allowing partial struct initialization and named parameter construction patterns throughout the codebase.

Closes #62 